### PR TITLE
updated tensorflow-probability to tensorflow-probability[tf] to fix TF-Keras installation issues 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 import versioneer
 
 requirements = [
-    'tensorflow>=2.0', 'tensorflow-probability',    # tfp for the Batch Norm (covariance)
+    'tensorflow>=2.0', 'tensorflow-probability[tf]',    # tfp for the Batch Norm (covariance)
     # 'tensorflow-addons',
     'numpy', 'six', 'packaging',
     'pandas', 'scipy',                   # Data


### PR DESCRIPTION
I was trying to implement the fashion-mnist example from the documentation but was having dependencies issues because tensorflow-probability doesn't automatically install tf_keras ( see: https://github.com/tensorflow/probability/releases). After I installed it correctly, I started getting another bug related to Keras's inability to identify the activation function. Somehow, it is calling keras instead of the functions specified in the repository, so it doesn't recognize it. So, before you push this change, please ensure it will still work with the new tensorflow-probability version.